### PR TITLE
[CIVIS-8354] MAINT pre-install requirements in Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [1.1.0] - 2024-05-24
+
+### Added
+- Docker image now pre-installs Python requirements for the demo app. (#2)
+
+### Changed
+- Updated demo app's dependencies to the latest versions: (#2)
+    * civis 2.0.0 -> 2.1.0
+    * streamlit 1.34.0 -> 1.35.0
+
 ## [1.0.0] - 2024-05-23
 
 First release!

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ ENV STREAMLIT_CLIENT_SHOW_ERROR_DETAILS=false \
     STREAMLIT_SERVER_PORT=3838 \
     STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
 
+COPY ./demo_app/requirements.txt .
+RUN pip install --progress-bar off --no-cache-dir -r requirements.txt && \
+    rm requirements.txt
+
 # Suppress the "Welcome to Streamlit" message at startup asking for an email address:
 # https://discuss.streamlit.io/t/streamlit-showing-me-welcome-to-streamlit-message-when-executing-it-with-docker/26168/2
 RUN mkdir -p ~/.streamlit/ && \

--- a/demo_app/requirements.txt
+++ b/demo_app/requirements.txt
@@ -1,4 +1,4 @@
-civis==2.0.0
+civis==2.1.0
 pandas==2.2.2
 scikit-learn==1.5.0
-streamlit==1.34.0
+streamlit==1.35.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,25 +16,15 @@ if [ ! -f requirements.txt ]; then
          "For your app's stability, it is strongly recommended that requirements.txt be provided" \
          "to pin the exact version of the Python dependencies." >&2
 else
-    echo "Installing dependencies"
-    pip install --progress-bar off -r requirements.txt
+    echo "Installing dependencies from requirements.txt"
+    pip install --progress-bar off --no-cache-dir -r requirements.txt
 fi
-
-for package in streamlit civis; do
-  if [[ ! -n $(command -v $package) ]]; then
-      echo "The package '$package' wasn't installed, so we're installing its latest version. " \
-           "It is strongly recommended that '$package' be pinned with a specific version in requirements.txt " \
-           "for your app's stability." >&2
-      pip install --progress-bar off $package
-  fi
-done
 
 if [ -f pyproject.toml ]; then
     echo "Installing python package defined by pyproject.toml"
     pip install --no-deps -e .
 fi
 
-pip cache purge
 pip list
 
 echo "Running Streamlit application"


### PR DESCRIPTION
To speed up the deployment of the demo app, after this pull request the demo app's Python requirements will be pre-installed in the Docker image.

---

**Note:** This GitHub repo is public.

- [x] (For Civis employees) Reference to an internal ticket number (in the form of `[CIVIS-xxxx]`) in the pull request title.
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level.
- [x] Description of change in the PR description.
- [x] The CircleCI builds have passed.
