### PR TITLE
[CIVIS-8775] ENH update dependency versions: civis-python 2.3.0, Python 3.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [1.2.0] - 2024-06-24
+
+### Changed
+- Updated Python version in Docker image: 3.12.3 -> 3.12.4. (#3)
+- Updated demo app's dependencies to the latest versions: (#3)
+    * civis 2.1.0 -> 2.3.0
+
 ## [1.1.0] - 2024-05-24
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/x86_64 python:3.12.3-slim AS base
+FROM --platform=linux/x86_64 python:3.12.4-slim AS base
 LABEL maintainer=opensource@civisanalytics.com
 
 # Supress pip user warnings:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ for service deployment.
 If you would like to start making the demo app your own
 by making code changes,
 you may [fork this GitHub repository](https://github.com/civisanalytics/civis-services-streamlit/fork)
+(note: your fork would be public; GitHub only allows public forks from a public repository)
 where the demo app's source code is in the directory [`demo_app/`](demo_app).
 If you would like to host and use your own Docker image,
 [`Dockerfile`](Dockerfile) and [`entrypoint.sh`](entrypoint.sh) from this GitHub repository
@@ -83,7 +84,7 @@ here are the requirements.
    specify the directory path that points to where the app code is located.
    (For the demo app in the previous section above, the directory path would be `demo_app` from this current repo.)
 5. For the Docker image, the name is `civisanalytics/civis-services-streamlit`,
-   and the tag is one of those [listed on DockerHub](https://hub.docker.com/repository/docker/civisanalytics/civis-services-streamlit/tags).
+   and the tag is one of those [listed on DockerHub](https://hub.docker.com/r/civisanalytics/civis-services-streamlit/tags).
    Note that the specific Docker image name and tag you've chosen determines which Python version
    your app is going to run on.
 

--- a/demo_app/app.py
+++ b/demo_app/app.py
@@ -41,8 +41,7 @@ def main():
 
     st.write(
         "To create your own app, "
-        "fork the [civis-services-streamlit GitHub repository](https://github.com/civisanalytics/civis-services-streamlit) "  # noqa: E501
-        "and follow the instructions."
+        "follow the instructions at the [civis-services-streamlit GitHub repository](https://github.com/civisanalytics/civis-services-streamlit)."  # noqa: E501
     )
 
     st.title("The Iris Dataset")

--- a/demo_app/requirements.txt
+++ b/demo_app/requirements.txt
@@ -1,4 +1,4 @@
-civis==2.1.0
+civis==2.3.0
 pandas==2.2.2
 scikit-learn==1.5.0
 streamlit==1.35.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 if [ ! -f requirements.txt ]; then
     echo "The file 'requirements.txt' is not found at $APP_DIR/$REPO_PATH_DIR." \
-         "For your app's stability, it is strongly recommended that requirements.txt be provided" \
+         "For your app's stability, it is strongly recommended that requirements.txt be provided " \
          "to pin the exact version of the Python dependencies." >&2
 else
     echo "Installing dependencies from requirements.txt"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ if [ ! -f app.py ]; then
 fi
 
 if [ ! -f requirements.txt ]; then
-    echo "The file 'requirements.txt' is not found at $APP_DIR/$REPO_PATH_DIR." \
+    echo "The file 'requirements.txt' is not found at $APP_DIR/$REPO_PATH_DIR. " \
          "For your app's stability, it is strongly recommended that requirements.txt be provided " \
          "to pin the exact version of the Python dependencies." >&2
 else


### PR DESCRIPTION
This pull request updates civis-python to v2.3.0 and Python to v3.12.4.

---

**Note:** This GitHub repo is public.

- [x] (For Civis employees) Reference to an internal ticket number (in the form of `[CIVIS-xxxx]`) in the pull request title.
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level.
- [x] Description of change in the PR description.
- [x] The CircleCI builds have passed.
