### PR TITLE
[CIVIS-9332] ENH update streamlit, sklearn, and python, switch from pip to uv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [1.3.0] - 2024-08-26
+
+### Changed
+- Updated Python version in Docker image: 3.12.4 -> 3.12.5. (#4)
+- Updated demo app's dependencies to the latest versions: (#4)
+    * scikit-learn 1.5.0 -> 1.5.1
+    * streamlit 1.35.0 -> 1.37.1
+- Switched from pip to uv for faster Python dependency installation. (#4)
+
 ## [1.2.0] - 2024-06-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-## [1.3.0] - 2024-08-26
+## [1.3.0] - 2024-08-23
 
 ### Changed
 - Updated Python version in Docker image: 3.12.4 -> 3.12.5. (#4)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/x86_64 python:3.12.4-slim AS base
+FROM --platform=linux/x86_64 python:3.12.5-slim AS base
 LABEL maintainer=opensource@civisanalytics.com
 
 # Supress pip user warnings:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,15 @@ ENV PIP_ROOT_USER_ACTION=ignore
 
 RUN apt-get update && apt-get install -y \
     git \
+    curl \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+
+# Install uv
+ADD https://astral.sh/uv/0.3.1/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+ENV PATH="/root/.cargo/bin/:$PATH" \
+    UV_SYSTEM_PYTHON=1
 
 WORKDIR /app
 
@@ -20,7 +28,7 @@ ENV STREAMLIT_CLIENT_SHOW_ERROR_DETAILS=false \
     STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
 
 COPY ./demo_app/requirements.txt .
-RUN pip install --progress-bar off --no-cache-dir -r requirements.txt && \
+RUN uv pip install --no-progress --no-cache -r requirements.txt && \
     rm requirements.txt
 
 # Suppress the "Welcome to Streamlit" message at startup asking for an email address:

--- a/demo_app/requirements.txt
+++ b/demo_app/requirements.txt
@@ -1,4 +1,4 @@
 civis==2.3.0
 pandas==2.2.2
-scikit-learn==1.5.0
-streamlit==1.35.0
+scikit-learn==1.5.1
+streamlit==1.37.1

--- a/demo_app/test_demo_app_on_ci.sh
+++ b/demo_app/test_demo_app_on_ci.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-pip install --progress-bar off -r /app/demo_app/requirements.txt && \
-pip list -v && \
+uv pip install --no-progress --no-cache -r /app/demo_app/requirements.txt && \
+uv pip list -v && \
 python -u << HERE
 from streamlit.testing.v1 import AppTest
 app = AppTest.from_file("/app/demo_app/app.py", default_timeout=10)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,15 +17,15 @@ if [ ! -f requirements.txt ]; then
          "to pin the exact version of the Python dependencies." >&2
 else
     echo "Installing dependencies from requirements.txt"
-    pip install --progress-bar off --no-cache-dir -r requirements.txt
+    uv pip install --no-progress --no-cache -r requirements.txt
 fi
 
 if [ -f pyproject.toml ]; then
     echo "Installing python package defined by pyproject.toml"
-    pip install --no-deps -e .
+    uv pip install --no-deps -e .
 fi
 
-pip list
+uv pip list
 
 echo "Running Streamlit application"
 streamlit run app.py


### PR DESCRIPTION
This pull request updates the versions of Streamlit, scikit-learn, and Python to their latest ones (see changelog updates for details), as well as switches from pip to uv for faster Python dependency installation.

---

**Note:** This GitHub repo is public.

- [x] (For Civis employees) Reference to an internal ticket number (in the form of `[CIVIS-xxxx]`) in the pull request title.
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level.
- [x] Description of change in the PR description.
- [x] The CircleCI builds have passed.
