### PR TITLE
[CIVIS-11075] ENH support arbitrary app file path, update to Python 3.13 and civis-python v2.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       # The Python version of this CircleCI image doesn't matter too much,
       # because we're going to build our image from our own Dockerfile
       # and run everything inside this image.
-      - image: cimg/python:3.12
+      - image: cimg/python:3.13
     steps:
       - checkout
       - setup_remote_docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [1.4.0] - 2024-07-09
+
+### Added
+- Added support for an entry point script whose filename isn't `app.py`,
+  in which case the user would need to specify the file path in the platform service object. (#5)
+
+### Changed
+- Updated Python version in Docker image: 3.12.5 -> 3.13.5. (#5)
+- Updated demo app's dependencies to the latest versions: (#5)
+    * civis 2.3.0 -> 2.7.1
+    * pandas 2.2.2 -> 2.3.0
+    * scikit-learn 1.5.1 -> 1.7.0
+    * streamlit 1.37.1 -> 1.46.1
+
 ## [1.3.0] - 2024-08-23
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/x86_64 python:3.12.5-slim AS base
+FROM --platform=linux/x86_64 python:3.13.5-slim AS base
 LABEL maintainer=opensource@civisanalytics.com
 
 # Supress pip user warnings:
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv
-ADD https://astral.sh/uv/0.3.1/install.sh /uv-installer.sh
+ADD https://astral.sh/uv/0.7.19/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.cargo/bin/:$PATH" \
     UV_SYSTEM_PYTHON=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM --platform=linux/x86_64 python:3.13.5-slim AS base
+ARG PLATFORM=linux/x86_64
+
+FROM --platform=$PLATFORM python:3.13.5-slim AS base
 LABEL maintainer=opensource@civisanalytics.com
 
 # Supress pip user warnings:
@@ -14,7 +16,7 @@ RUN apt-get update && apt-get install -y \
 # Install uv
 ADD https://astral.sh/uv/0.7.19/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
-ENV PATH="/root/.cargo/bin/:$PATH" \
+ENV PATH="/root/.local/bin/:$PATH" \
     UV_SYSTEM_PYTHON=1
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ here are the requirements.
 
      A required file.
      `app.py` is your Streamlit app's entry point.
-     For which Python version you should use (e.g., Python 3.12),
+     For which Python version you should use (e.g., Python 3.13),
      it is determined by which Docker image name and tag you're going to use
      to deploy your app on Civis Platform.
      The Python version is specified by the base image in the file `Dockerfile`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ here are the requirements.
    The Civis Platform user account that's going to deploy this Streamlit app must have
    access to this GitHub repo.
 2. The following explains the expected files for your app.
-   Note that these files listed should be at the same directory in your GitHub repository.
+   Note that these files listed must be at the same directory in your GitHub repository.
 
    * Your app's entry-point Python script
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,17 @@ here are the requirements.
 1. Your Streamlit application must have its source code hosted on a GitHub repository.
    The Civis Platform user account that's going to deploy this Streamlit app must have
    access to this GitHub repo.
-2. The following explains the expected files for your app:
+2. The following explains the expected files for your app.
+   Note that these files listed should be at the same directory in your GitHub repository.
 
-   * `app.py`
+   * Your app's entry-point Python script
 
-     A required file.
-     `app.py` is your Streamlit app's entry point.
+     A required file, with a file extension name `.py` for a Python script.
+     This is your Streamlit app's entry point.
+     The recommended filename is `app.py`.
+     If you use a filename different from `app.py`,
+     you must specify its file path, starting from your repo's root (e.g., `from/repo_root/to/your_custom_app.py`),
+     in the Civis Platform service your're going to set up (see below).
      For which Python version you should use (e.g., Python 3.13),
      it is determined by which Docker image name and tag you're going to use
      to deploy your app on Civis Platform.
@@ -83,6 +88,9 @@ here are the requirements.
 4. If your code is at a directory in your repo (rather than directly at the root level of your repo),
    specify the directory path that points to where the app code is located.
    (For the demo app in the previous section above, the directory path would be `demo_app` from this current repo.)
+   By default, your Streamlit app's entry point Python script is assumed to be named `app.py`.
+   If you use a filename other than `app.py`,
+   you must specify its file path starting from the repo root, e.g., `from/repo_root/to/your_custom_app.py`.
 5. For the Docker image, the name is `civisanalytics/civis-services-streamlit`,
    and the tag is one of those [listed on DockerHub](https://hub.docker.com/r/civisanalytics/civis-services-streamlit/tags).
    Note that the specific Docker image name and tag you've chosen determines which Python version

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ here are the requirements.
    * Your app's entry-point Python script
 
      A required file, with a file extension name `.py` for a Python script.
-     This is your Streamlit app's entry point.
+     This is your Streamlit app's entry point
+     (i.e., `streamlit run <something>.py` will be executed to spin up your app).
      The recommended filename is `app.py`, but if you use a different filename,
      you must specify its file path
      (starting from your repo's root, e.g., `from/repo_root/to/your_custom_app.py`)

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ here are the requirements.
 
      A required file, with a file extension name `.py` for a Python script.
      This is your Streamlit app's entry point.
-     The recommended filename is `app.py`.
-     If you use a filename different from `app.py`,
-     you must specify its file path, starting from your repo's root (e.g., `from/repo_root/to/your_custom_app.py`),
+     The recommended filename is `app.py`, but if you use a different filename,
+     you must specify its file path
+     (starting from your repo's root, e.g., `from/repo_root/to/your_custom_app.py`)
      in the Civis Platform service your're going to set up (see below).
      For which Python version you should use (e.g., Python 3.13),
      it is determined by which Docker image name and tag you're going to use

--- a/demo_app/README.md
+++ b/demo_app/README.md
@@ -3,11 +3,12 @@
 We strongly recommend pinning the exact package versions
 (i.e., using double-equals `==`) in `requirements.txt`.
 
-For stability in production, especially if you have more complicated requirements,
-we recommend pinning the exact versions of both the dependencies
+For stability in production, we recommend locking down the execution environment by
+pinning the exact versions of both the dependencies
 your code imports and their transitive dependencies.
-For this purpose, we recommend [pip-tools](https://pip-tools.readthedocs.io/en/latest/)
-to generate `requirements.txt`.
+Tools for generating a "full" `requirements.txt` include
+[uv](https://docs.astral.sh/uv/) and 
+[pip-tools](https://pip-tools.readthedocs.io/en/latest/).
 
 ## Running the demo app locally
 

--- a/demo_app/requirements.txt
+++ b/demo_app/requirements.txt
@@ -1,4 +1,4 @@
-# You can modify the packages listed and their versions as desired.
+# In your own app, you can modify the packages listed and their versions as desired.
 # As a best practice for stability, specify the exact version (i.e., use "==") of each package to be installed.
 # Include only packages that are actually imported in your app code.
 

--- a/demo_app/requirements.txt
+++ b/demo_app/requirements.txt
@@ -1,4 +1,4 @@
-# In your own app, you can modify the packages listed and their versions as desired.
+# You can add/remove packages or change the package versions listed below as desired.
 # As a best practice for stability, specify the exact version (i.e., use "==") of each package to be installed.
 # Include only packages that are actually imported in your app code.
 

--- a/demo_app/requirements.txt
+++ b/demo_app/requirements.txt
@@ -1,4 +1,8 @@
-civis==2.3.0
-pandas==2.2.2
-scikit-learn==1.5.1
-streamlit==1.37.1
+# You can modify this list by adding or removing packages, also updating the package versions as desired.
+# As a best practice for stability, specify the exact version (i.e., use "==") of each package to be installed.
+# Include only packages that are actually imported in your app code.
+
+civis==2.7.1
+pandas==2.3.0
+scikit-learn==1.7.0
+streamlit==1.46.1

--- a/demo_app/requirements.txt
+++ b/demo_app/requirements.txt
@@ -1,4 +1,4 @@
-# You can modify this list by adding or removing packages, also updating the package versions as desired.
+# You can modify the packages listed and their versions as desired.
 # As a best practice for stability, specify the exact version (i.e., use "==") of each package to be installed.
 # Include only packages that are actually imported in your app code.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ elif [ -f "$REPO_PATH_DIR" ]; then
     export APP_PY="$(basename "$REPO_PATH_DIR")"
     export REPO_PATH_DIR="$(dirname "$REPO_PATH_DIR")"
 elif [ -z "$REPO_PATH_DIR" ] || [ "$REPO_PATH_DIR" = "." ]; then
-    echo "No specific path provided for the Streamlit app. Defaulting to the current directory. The app's entry point is assumed to be at ./app.py."
+    echo "No specific path provided for the Streamlit app. Defaulting to the repo's root directory. The app's entry point is assumed to be at ./app.py."
     export REPO_PATH_DIR="."
     export APP_PY="app.py"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,13 +7,14 @@ python --version
 cd "$APP_DIR"
 
 if [ -d "$REPO_PATH_DIR" ]; then
-    echo "$REPO_PATH_DIR is a directory. Your Streamlit app's entry point is assumed to be at $REPO_PATH_DIR/app.py."
+    echo "The specified path $REPO_PATH_DIR is a directory. Your Streamlit app's entry point is assumed to be at $REPO_PATH_DIR/app.py."
     export APP_PY="app.py"
 elif [ -f "$REPO_PATH_DIR" ]; then
-    echo "$REPO_PATH_DIR is a file, assumed to be the entry point of your Streamlit app."
+    echo "The specified path $REPO_PATH_DIR is a file, assumed to be the entry point of your Streamlit app."
     export APP_PY="$(basename "$REPO_PATH_DIR")"
     export REPO_PATH_DIR="$(dirname "$REPO_PATH_DIR")"
 elif [ -z "$REPO_PATH_DIR" ] || [ "$REPO_PATH_DIR" = "." ]; then
+    echo "No specific path provided for the Streamlit app. Defaulting to the current directory. The app's entry point is assumed to be at ./app.py."
     export REPO_PATH_DIR="."
     export APP_PY="app.py"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,9 @@ elif [ -f "$REPO_PATH_DIR" ]; then
     echo "$REPO_PATH_DIR is a file, assumed to be the entry point of your Streamlit app."
     export APP_PY="$(basename "$REPO_PATH_DIR")"
     export REPO_PATH_DIR="$(dirname "$REPO_PATH_DIR")"
+elif [ -z "$REPO_PATH_DIR" ] || [ "$REPO_PATH_DIR" = "." ]; then
+    export REPO_PATH_DIR="."
+    export APP_PY="app.py"
 else
     echo "The specified path '$REPO_PATH_DIR' does not exist." >&2
     echo "Please ensure that the path is correct and that it points to your Streamlit app's directory or file." >&2
@@ -27,7 +30,7 @@ if [ ! -f "$APP_PY" ]; then
 fi
 
 if [ ! -f requirements.txt ]; then
-    echo "The file 'requirements.txt' is not found at $REPO_PATH_DIR. " \
+    echo "The file 'requirements.txt' is not found. " \
          "For your app's stability, it is strongly recommended that requirements.txt be provided " \
          "to pin the exact version of the Python dependencies." >&2
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,15 +4,30 @@ set -e
 
 python --version
 
-cd "$APP_DIR/$REPO_PATH_DIR"
+cd "$APP_DIR"
 
-if [ ! -f app.py ]; then
-    echo "The required file 'app.py' is not found at $APP_DIR/$REPO_PATH_DIR" >&2
+if [ -d "$REPO_PATH_DIR" ]; then
+    echo "$REPO_PATH_DIR is a directory. Your Streamlit app's entry point is assumed to be at $REPO_PATH_DIR/app.py."
+    EXPORT APP_PY="app.py"
+elif [ -f "$REPO_PATH_DIR" ]; then
+    echo "$REPO_PATH_DIR is a file, assumed to be the entry point of your Streamlit app."
+    EXPORT APP_PY="$(basename "$REPO_PATH_DIR")"
+    EXPORT REPO_PATH_DIR="$(dirname "$REPO_PATH_DIR")"
+else
+    echo "The specified path '$REPO_PATH_DIR' does not exist." >&2
+    echo "Please ensure that the path is correct and that it points to your Streamlit app's directory or file." >&2
+    exit 1
+fi
+
+cd "$REPO_PATH_DIR"
+
+if [ ! -f "$APP_PY" ]; then
+    echo "The expected Streamlit app entry point file is not found at $REPO_PATH_DIR/$APP_PY" >&2
     exit 1
 fi
 
 if [ ! -f requirements.txt ]; then
-    echo "The file 'requirements.txt' is not found at $APP_DIR/$REPO_PATH_DIR. " \
+    echo "The file 'requirements.txt' is not found at $REPO_PATH_DIR. " \
          "For your app's stability, it is strongly recommended that requirements.txt be provided " \
          "to pin the exact version of the Python dependencies." >&2
 else
@@ -28,4 +43,4 @@ fi
 uv pip list
 
 echo "Running Streamlit application"
-streamlit run app.py
+streamlit run "$APP_PY"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,11 +8,11 @@ cd "$APP_DIR"
 
 if [ -d "$REPO_PATH_DIR" ]; then
     echo "$REPO_PATH_DIR is a directory. Your Streamlit app's entry point is assumed to be at $REPO_PATH_DIR/app.py."
-    EXPORT APP_PY="app.py"
+    export APP_PY="app.py"
 elif [ -f "$REPO_PATH_DIR" ]; then
     echo "$REPO_PATH_DIR is a file, assumed to be the entry point of your Streamlit app."
-    EXPORT APP_PY="$(basename "$REPO_PATH_DIR")"
-    EXPORT REPO_PATH_DIR="$(dirname "$REPO_PATH_DIR")"
+    export APP_PY="$(basename "$REPO_PATH_DIR")"
+    export REPO_PATH_DIR="$(dirname "$REPO_PATH_DIR")"
 else
     echo "The specified path '$REPO_PATH_DIR' does not exist." >&2
     echo "Please ensure that the path is correct and that it points to your Streamlit app's directory or file." >&2


### PR DESCRIPTION
This pull request adds support for an arbitrary app file path, also updates the image to Python 3.13 and civis-python v2.7.1.

Please see the comments of the linked internal ticket for testing.

---

**Note:** This GitHub repo is public.

- [x] (For Civis employees) Reference to an internal ticket number (in the form of `[CIVIS-xxxx]`) in the pull request title.
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level.
- [x] Description of change in the PR description.
- [x] The CircleCI builds have passed.
