### PR TITLE
[CIVIS-11793] Upgrade to streamlit 1.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## [1.5.0] - 2025-10-21
+
+### Added
 
 - Added example config.toml with Civis styling in demo_app. (#6)
 
@@ -17,11 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * pandas 2.3.0 -> 2.3.3
     * scikit-learn 1.7.0 -> 1.7.2
     * streamlit 1.46.1 -> 1.50.0
-
-### Deprecated
-### Removed
-### Fixed
-### Security
 
 ## [1.4.0] - 2024-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added example config.toml with Civis styling in demo_app. (#6)
 
 ### Changed
+
+- Updated demo app's dependencies to the latest versions: (#7)
+    * pandas 2.3.0 -> 2.3.3
+    * scikit-learn 1.7.0 -> 1.7.2
+    * streamlit 1.46.1 -> 1.50.0
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/demo_app/requirements.txt
+++ b/demo_app/requirements.txt
@@ -3,6 +3,6 @@
 # Include only packages that are actually imported in your app code.
 
 civis==2.7.1
-pandas==2.3.0
-scikit-learn==1.7.0
-streamlit==1.46.1
+pandas==2.3.3
+scikit-learn==1.7.2
+streamlit==1.50.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+# This file is to facilitate local development for maintenance of the Dockerfile
+# and demo app. To run the app locally, execute the following:
+# `docker-compose build && docker-compose up`
+# and then open http://127.0.0.1:3838/ in your browser.
+services:
+  demo-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+    ports:
+      - "3838:3838"
+    environment:
+      - APP_DIR=/app
+      - REPO_PATH_DIR=demo_app
+    volumes:
+      - .:/app


### PR DESCRIPTION
This updates the image and demo app to use streamlit 1.50.0.

It also adds a simple docker compose config file for testing.

I made [a service](https://platform.civisanalytics.com/spa/#/services/5751) in Civis Platform to check this.

---

**Note:** This GitHub repo is public.

- [x] (For Civis employees) Reference to an internal ticket number (in the form of `[CIVIS-xxxx]`) in the pull request title.
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level.
- [x] Description of change in the PR description.
- [x] The CircleCI builds have passed.
