### PR TITLE
[CIVIS-13170] ENH civis-python to 2.9.1, plus other minor version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.6.0] - 2026-05-06
 
 - Updated Python version: 3.13.5 -> 3.13.13. (#8)
-- Updated uv version: 0.7.9 -> 0.11.8. (#8)
+- Updated uv version: 0.7.19 -> 0.11.8. (#8)
 - Updated demo app's dependencies to the latest versions: (#8)
     * civis 2.7.1 -> 2.9.1
     * scikit-learn 1.7.2 -> 1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [1.6.0] - 2026-05-06
+
+- Updated Python version: 3.13.5 -> 3.13.13. (#8)
+- Updated uv version: 0.7.9 -> 0.11.8. (#8)
+- Updated demo app's dependencies to the latest versions: (#8)
+    * civis 2.7.1 -> 2.9.1
+    * scikit-learn 1.7.2 -> 1.8.0
+    * streamlit 1.50.0 -> 1.57.0
+
 ## [1.5.0] - 2025-10-21
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM=linux/x86_64
 
-FROM --platform=$PLATFORM python:3.13.5-slim AS base
+FROM --platform=$PLATFORM python:3.13.13-slim AS base
 LABEL maintainer=opensource@civisanalytics.com
 
 # Supress pip user warnings:
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv
-ADD https://astral.sh/uv/0.7.19/install.sh /uv-installer.sh
+ADD https://astral.sh/uv/0.11.8/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.local/bin/:$PATH" \
     UV_SYSTEM_PYTHON=1

--- a/demo_app/requirements.txt
+++ b/demo_app/requirements.txt
@@ -2,7 +2,7 @@
 # As a best practice for stability, specify the exact version (i.e., use "==") of each package to be installed.
 # Include only packages that are actually imported in your app code.
 
-civis==2.7.1
+civis==2.9.1
 pandas==2.3.3
-scikit-learn==1.7.2
-streamlit==1.50.0
+scikit-learn==1.8.0
+streamlit==1.57.0


### PR DESCRIPTION
This pull request upgrades the minor / patch versions of various dependencies, especially civis-python (to 2.9.1).

---

**Note:** This GitHub repo is public.

- [x] (For Civis employees) Reference to an internal ticket number (in the form of `[CIVIS-xxxx]`) in the pull request title.
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level.
- [x] Description of change in the PR description.
- [x] The CircleCI builds have passed.
