### PR TITLE
[CIVIS-13726] ENH Python 3.13 -> 3.14, Pandas 2.x -> 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,18 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The version number has incremented from 1.x.x to 2.x.x due to breaking changes
 from Python 3.13 -> 3.14 and Pandas 2.x -> 3.x.
 
-- Updated Python version: 3.13.13 -> 3.14.6. (#9)
-- Updated uv version: 0.11.8 -> 0.11.28. (#9)
-- Updated demo app's dependencies to the latest versions: (#9)
+- Updated Python version: 3.13.13 -> 3.14.6. (#11)
+- Updated uv version: 0.11.8 -> 0.11.28. (#11)
+- Updated demo app's dependencies to the latest versions: (#11)
     * pandas 2.3.3 -> 3.0.3
     * scikit-learn 1.8.0 -> 1.9.0
     * streamlit 1.57.0 -> 1.59.2
 
 ## [1.6.0] - 2026-05-06
 
-- Updated Python version: 3.13.5 -> 3.13.13. (#8)
-- Updated uv version: 0.7.19 -> 0.11.8. (#8)
-- Updated demo app's dependencies to the latest versions: (#8)
+- Updated Python version: 3.13.5 -> 3.13.13. (#10)
+- Updated uv version: 0.7.19 -> 0.11.8. (#10)
+- Updated demo app's dependencies to the latest versions: (#10)
     * civis 2.7.1 -> 2.9.1
     * scikit-learn 1.7.2 -> 1.8.0
     * streamlit 1.50.0 -> 1.57.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [2.0.0] - 2026-07-15
+
+The version number has incremented from 1.x.x to 2.x.x due to breaking changes
+from Python 3.13 -> 3.14 and Pandas 2.x -> 3.x.
+
+- Updated Python version: 3.13.13 -> 3.14.6. (#9)
+- Updated uv version: 0.11.8 -> 0.11.28. (#9)
+- Updated demo app's dependencies to the latest versions: (#9)
+    * pandas 2.3.3 -> 3.0.3
+    * scikit-learn 1.8.0 -> 1.9.0
+    * streamlit 1.57.0 -> 1.59.2
+
 ## [1.6.0] - 2026-05-06
 
 - Updated Python version: 3.13.5 -> 3.13.13. (#8)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM=linux/x86_64
 
-FROM --platform=$PLATFORM python:3.13.13-slim AS base
+FROM --platform=$PLATFORM python:3.14.6-slim AS base
 LABEL maintainer=opensource@civisanalytics.com
 
 # Supress pip user warnings:
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv
-ADD https://astral.sh/uv/0.11.8/install.sh /uv-installer.sh
+ADD https://astral.sh/uv/0.11.28/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.local/bin/:$PATH" \
     UV_SYSTEM_PYTHON=1

--- a/demo_app/requirements.txt
+++ b/demo_app/requirements.txt
@@ -3,6 +3,6 @@
 # Include only packages that are actually imported in your app code.
 
 civis==2.9.1
-pandas==2.3.3
-scikit-learn==1.8.0
-streamlit==1.57.0
+pandas==3.0.3
+scikit-learn==1.9.0
+streamlit==1.59.2


### PR DESCRIPTION
This PR updates dependency versions, notably with two breaking changes: Python 3.13 -> 3.14, Pandas 2.x -> 3.x

---

**Note:** This GitHub repo is public.

- [x] (For Civis employees) Reference to an internal ticket number (in the form of `[CIVIS-xxxx]`) in the pull request title.
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level.
- [x] Description of change in the PR description.
- [x] The CircleCI builds have passed.
